### PR TITLE
Add !falsequartering command

### DIFF
--- a/ht/cogs/reference.py
+++ b/ht/cogs/reference.py
@@ -168,6 +168,14 @@ class HeraldryReference(utils.MeldedCog, name = "Reference", category = "Heraldr
 	async def fridge(self, ctx):
 		with open("media/prose/fridgetesting.md", "r") as file:
 			await ctx.send(file.read())
+			
+	@commands.command(
+		help = "Shows a short blurb about false quartering.",
+		aliases = ("fq")
+	)
+	async def falsequartering(self, ctx):
+		with open("media/prose/falsequartering.md", "r") as file:
+			await ctx.send(file.read())
 
 async def setup(bot):
 	await bot.add_cog(HeraldryReference(bot))

--- a/ht/cogs/reference.py
+++ b/ht/cogs/reference.py
@@ -171,7 +171,7 @@ class HeraldryReference(utils.MeldedCog, name = "Reference", category = "Heraldr
 			
 	@commands.command(
 		help = "Shows a short blurb about false quartering.",
-		aliases = ("fq")
+		aliases = ("fq",)
 	)
 	async def falsequartering(self, ctx):
 		with open("media/prose/falsequartering.md", "r") as file:

--- a/media/prose/falsequartering.md
+++ b/media/prose/falsequartering.md
@@ -1,0 +1,2 @@
+<:lion_smile:961787183918882837> "Quartering" is used to combine multiple arms that you have the right to bear — usually combining arms from both of your parents, or from multiple ruled territories.
+<:lion_smile:961787183918882837> "False quartering" refers to arms that misleadingly look as though they were created by quartering other arms, but were not.


### PR DESCRIPTION
The new !falsequartering command (aliases: !fq !false-quartering) shows a text blurb about what false quartering means and why it is generally not recommended.

Proposed in
https://discord.com/channels/272117928298676225/922895221707124738/1167412971643867187.